### PR TITLE
feat(api/collect): Add HMAC auth and audit trail to /collect endpoint

### DIFF
--- a/scripts/gen_hmac.py
+++ b/scripts/gen_hmac.py
@@ -4,8 +4,8 @@ import base64
 
 # ==== CONFIGURE THESE ====
 secret = "super_secret_key_123"        # Must match your backend
-idempotency_key = "op-test-20240603-xyz"       # Change per request/test
-body = '{"senderUpi":"toby@upi","receiverUpi":"grace@upi","amount":7182.50}'  # Exactly as in curl -d
+idempotency_key = "op-collect-20240603-testA"       # Change per request/test
+body = '{"senderUpi":"oliver@upi","receiverUpi":"lucas@upi","amount":3490.40}'  # Exactly as in curl -d
 
 # ==== MUST CONCATENATE LIKE BACKEND ====
 message = body + idempotency_key


### PR DESCRIPTION
- Implemented secure HMAC authentication for /collect (pull payment) API.
- Enforced idempotency and validation at service layer.
- Persist collect requests with requested status and full audit history.
- Integrated Redis stream queuing for worker consumption.
- E2E tested with fresh DB/Redis: correct state transitions, retry, completion.